### PR TITLE
fix: :goal_net: catch fetch errors and send it to front

### DIFF
--- a/apps/server/src/controllers/repository.js
+++ b/apps/server/src/controllers/repository.js
@@ -160,7 +160,9 @@ export const createRepositoryController = async (req, res) => {
         'request-id': req.id,
       },
     })
-    addLogs(await ansibleRes.json(), userId)
+    const resJson = await ansibleRes.json()
+    await addLogs(resJson, userId)
+    if (resJson.status !== 'OK') throw new Error(`Echec de création du repo ${repo.internalRepoName} côté ansible`)
 
     try {
       await updateRepositoryCreated(repo.id)
@@ -179,7 +181,7 @@ export const createRepositoryController = async (req, res) => {
       return send500(res, error.message)
     }
   } catch (error) {
-    const message = `Provisioning repo with ansible failed: ${error.message}`
+    const message = `Echec requête ${req.id} : ${error.message}`
     req.log.error({
       ...getLogInfos(),
       description: message,
@@ -357,7 +359,9 @@ export const deleteRepositoryController = async (req, res) => {
         'request-id': req.id,
       },
     })
-    addLogs(await ansibleRes.json(), userId)
+    const resJson = await ansibleRes.json()
+    await addLogs(resJson, userId)
+    if (resJson.status !== 'OK') throw new Error(`Echec de suppression du repo ${repo.internalRepoName} côté ansible`)
 
     try {
       await deleteRepository(repositoryId)


### PR DESCRIPTION
Besoin d'entourer requêtes `fetch` avec un try catch car :

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch

`The Promise returned from fetch() won't reject on HTTP error status even if the response is an HTTP 404 or 500`